### PR TITLE
update license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# Helium Toolchain Common License
 
-Copyright (c) 2020 ExaInsanity
+Copyright (c) 2020-2021 ExaInsanity, Zefyro and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11,6 +11,22 @@ furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
+The Software, or any part of it, shall not be used in any practice which satisfies
+at least one of the following conditions:
+
+- breaking any applicable license agreements and law, INCLUDING those provided
+  by Mojang Studios or Microsoft Corporation applying to Minecraft: Java Edition, or
+- causing harm, with or without malicious intent, to any other individual
+  or legal entity
+
+Additionally, if your work references the Helium Toolchain in any way, is 
+designed for use with the Helium Toolchain or is based on the Helium Toolchain 
+in any way, it is subject to all requirements of this license, its license
+must be compatible with this license, it must be open and honest about its
+feature and functionality set and it must, under all circumstances, follow
+Mojang Studios and Microsoft Corporation rules in connection to Minecraft:
+Java Edition, save only those not applicable to the Helium Toolchain.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/Xenon.InstallerLoader/IInstaller.cs
+++ b/src/Xenon.InstallerLoader/IInstaller.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Xenon.InstallerLoader
+{
+    /// <summary>
+    /// Base interface for any installer. Each installer must have one class implementing this interface.
+    /// </summary>
+	public interface IInstaller
+	{
+        /// <summary>
+        /// Called when the installer is loaded.
+        /// </summary>
+        public void Initialize();
+
+        /// <summary>
+        /// Called when the launcher is shut down, in case files need to be closed etc.
+        /// </summary>
+        public void Disable();
+	}
+}

--- a/src/Xenon.InstallerLoader/Metadata/InstallerData.cs
+++ b/src/Xenon.InstallerLoader/Metadata/InstallerData.cs
@@ -31,13 +31,13 @@ namespace Xenon.InstallerLoader.Metadata
 
 
 		[JsonPropertyName("depends")]
-		public Dictionary<String, String> Depends { get; set; }
+		public String[] Depends { get; set; }
 
 		[JsonPropertyName("breaks")]
-		public Dictionary<String, String> Incompatible { get; set; }
+		public String[] Incompatible { get; set; }
 
 		[JsonPropertyName("recommends")]
-		public Dictionary<String, String> Recommends { get; set; }
+		public String[] Recommends { get; set; }
 
 		[JsonPropertyName("author")]
 		public String[] Authors { get; set; }

--- a/src/Xenon.InstallerLoader/Metadata/VersionJsonConverter.cs
+++ b/src/Xenon.InstallerLoader/Metadata/VersionJsonConverter.cs
@@ -8,9 +8,7 @@ namespace Xenon.InstallerLoader.Metadata
 	{
 		public override TypeLib.Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-#pragma warning disable CS8602
 			String[] sv = reader.GetString().Split('.');
-#pragma warning restore CS8602
 
 			if(sv.Length != 3)
 			{

--- a/src/Xenon.Installers.MojangClient/Xenon.Installers.MojangClient.csproj
+++ b/src/Xenon.Installers.MojangClient/Xenon.Installers.MojangClient.csproj
@@ -20,6 +20,7 @@
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<Exec Command="if not exist &quot;$(TargetDir)\installers&quot; mkdir $(TargetDir)\installers" />
+		<Exec Command="del $(TargetDir)\Xenon.Installers.MojangClient.deps.json" />
 		<Exec Command="move $(TargetDir)\Xenon.Installers.MojangClient.* $(TargetDir)\installers" />
 		<Exec Command="move $(TargetDir)\mojangclient.json $(TargetDir)\installers" />
 	</Target>

--- a/src/Xenon.Installers.MojangClient/mojangclient.json
+++ b/src/Xenon.Installers.MojangClient/mojangclient.json
@@ -8,15 +8,15 @@
   "issues": "https://github.com/ExaInsanity/xenon/issues",
   "homepage": "https://irisfeanora.net/",
 
-  "depends": {
+  "depends": [
 
-  },
-  "breaks": {
+  ],
+  "breaks": [
 
-  },
-  "recommends": {
-    "mojangserver": "*"
-  },
+  ],
+  "recommends": [
+    "mojangserver"
+  ],
 
   "authors": [
     "ExaInsanity",


### PR DESCRIPTION
As discussed in #xenon, Xenon will now use the HTCL instead of MIT